### PR TITLE
Updated workshop date and time zone

### DIFF
--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -23,7 +23,7 @@ CANOPIE-HPC is a workshop focusing on containerization, virtualization, and othe
 * Submission closes:    August XX, 2023
 * Decisions:    September XX, 2023
 * Camera ready due:    October XX, 2023
-* Workshop date:    TBD
+* Workshop date:    November 13, 2023
 
 **Note: Items are due at 23:59 “anywhere on Earth” on the specified date. Specifically, this is 23:59 IDLW, i.e., UTC–12:00.**
 

--- a/docs/program.md
+++ b/docs/program.md
@@ -5,15 +5,17 @@ hide:
 ---
 
 ## CANOPIE-HPC 2023 Workshop Program
-Monday, November 14th, 2023
+Monday, November 13th, 2023
 TBD
 
-** Note all times list CENTRAL TIME (UTC–6) **
+** Note all times list MOUNTAIN TIME (UTC–7) **
 
 
 ## Agenda
 
-We plan to have a combination of Invited Speakers, Research Paper Presentations, Lightning Talks, and Panel sessions.
+We plan to have a combination of Research Paper Presentations, Lightning Talks, and Panel sessions.
+
+<!---
 
 <table>
 <thead>
@@ -34,3 +36,5 @@ We plan to have a combination of Invited Speakers, Research Paper Presentations,
     </tr>
 </tbody>
 </table>
+
+-->


### PR DESCRIPTION
Should we write the workshop date in the homepage too?