### PR TITLE
update with sc23 cfp, other changes

### DIFF
--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -7,66 +7,150 @@ hide:
 
 ### Program chairs:
 
-* Laurie Stephey, Lawrence Berkeley National Lab
 * Alberto Madona Madonna, CSCS
-
+* Laurie Stephey, Lawrence Berkeley National Lab
 
 * Shane Canon, Lawrence Berkeley National Lab
 * Andrew Younge, Sandia National Labs
 
-CANOPIE-HPC is a workshop focusing on containerization, virtualization, and other methods to implement user-defined, bring-your-own, or isolated software environments. Submissions will be peer-reviewed, and accepted papers will be published in IEEE  Computer Society.
+CANOPIE-HPC is a workshop focusing on containerization, virtualization, and
+other methods to implement user-defined, bring-your-own, or isolated software
+environments. Submissions will be peer-reviewed, and accepted papers will be
+published in IEEE  Computer Society.
 
 ### Important Dates
 
-
-* Submission opens:    June XX, 2023
-* Submission closes:    August XX, 2023
-* Decisions:    September XX, 2023
-* Camera ready due:    October XX, 2023
+* Submission opens:    June 1, 2023
+* Submission closes (hard deadline- no extensions):    August 18, 2023
+* Decisions:    September 8, 2023
+* Camera ready deadline:    September 29, 2023
 * Workshop date:    November 13, 2023
 
 **Note: Items are due at 23:59 “anywhere on Earth” on the specified date. Specifically, this is 23:59 IDLW, i.e., UTC–12:00.**
 
 ### Overview
-Technologies such as containers and virtual machines enable users to define and build their own software environments, and then run them on different resources in a portable, reproducible manner. These new workflows, with users directly participating in creating and managing environments with tools such as Vagrant, OpenStack, Docker, Podman, Singularity, Shifter, and Charliecloud, are a transformational capability. In addition to greater flexibility and agility for users, other benefits include greater portability and reduced system administration costs. In particular, they make tractable a much-desired paradigm shift in software deployment, enabling an HPC application and its environment to be moved between platforms ranging from development laptops and desktops to exascale HPC systems.
 
-While adoption is growing, there remain numerous questions regarding best practices, foundational concepts, tools, and standards. Our goal is to promote and accelerate the adoption and impact of this new ecosystem to better address HPC use cases. This workshop serves as a key venue for presenting late-breaking research, sharing experiences and best practices, and fostering collaboration in this field. Our second iteration will emphasize real-world experiences and challenges with such environments.
+The ongoing revolution enabled via containerization, virtualization, and new
+orchestration models has dramatically changed how applications and services are
+delivered and managed across the computing industry. This revolution has
+established a new ecosystem of tools and techniques with new, flexible and
+agile approaches, and continues to gain traction in the HPC community. In
+addition to HPC-optimized container runtimes, emerging technologies like
+Kubernetes create a new set of opportunities and challenges. While adoption is
+growing, questions regarding best practices, foundational concepts, tools, and
+standards remain. Our goal is to promote the adoption of these tools and
+introspect the impact of this new ecosystem on HPC use cases. This workshop
+serves as a key venue for presenting late-breaking research, sharing
+experiences and best practices, and fostering collaboration in this field. Our
+fifth workshop iteration will continue to emphasize real-world experiences and
+challenges in adopting and optimizing these new approaches for HPC.
 
 ### Scope
-The scope of this workshop is to better understand and improve user-defined, bring-your-own, isolated, and related software environments for HPC. The most well-known approaches are containers and virtualization, but anything to further these goals is welcome. Topics include but are not limited to:
 
-* Container runtimes, virtual machines, and related technologies
-* Portability and reproducibility
-* Experience reports, at both applications and systems levels
-* Exascale considerations
+The scope of this workshop is to better understand and improve paradigms around
+containerization, virtualization and orchestration for HPC use cases. The most
+well-known approaches are containers and virtualization, but anything to
+further these goals is welcome. Topics include but are not limited to:
+
+* Container runtimes, virtual machine implementations, and other related technologies
+* Perspectives from container framework developers and  maintainers
+* System and architecture portability
+* Scientific reproducibility, including FAIR considerations 
+* Experience reports from users, developers, and system administrators
+* Lessons from exascale
 * HPC in the cloud and/or cloud in the HPC
-* Hardware considerations, including GPUs, accelerators, and interconnects
-* Security and trust models
-* Image management, including distribution and archiving as well as registries
-* In-situ visualization and/or analysis
-* Debugging
-* Workflows, including interaction between traditional jobs, non-traditional jobs, and services; checkpoint/restart; monitoring; and resource partitioning
-* Orchestration, resource management, and scheduling
-* Performance and scaling studies
-* New interaction techniques such as web apps (Jupyter, RStudio, etc.) and DevOps
+* GPUs, accelerators, proprietary interconnects, and other hardware considerations
+* Security considerations when adopting container technologies, including zero trust models
+* Container and virtual machine image management, including distribution and archiving
+* Workflows, including interaction between traditional HPC applications and containerized workflows or edge services
+* Performance and scaling studies with containers and/or VMs
+* Orchestration, scheduling, and/or resource management of jobs and microservices
+* New interaction techniques such as web apps (Jupyter, Rstudio, etc.)
+* Community standards, including OCI 
+* Role of containerization in DevOps (ex: Gitlab CI/CD) 
+* Efforts to provide and curate containers
+* Improving container user experience
+* Future of containers (ex: web assembly, portability) 
+* Perspectives on container outreach- convincing native application users/devs to make the jump
 
 ### Workshop format
-CANOPIE-HPC will follow a relatively traditional format based on several other previously successful workshops at SC, consisting of approximately four sessions separated by breaks and lunch. We will have an introduction and welcoming remarks, technical talks, panels, a keynote, and a brief wrap-up discussion. The content of technical sessions will be driven by the curated mix of accepted submissions. In the event of a virtual SC23, CANOPIE-HPC will follow remote guidance from the SC23 organizers, with the goal of simulating an in-person workshop as closely as practical.
+
+Although in the past several years CANOPIE-HPC has followed a more traditional
+format, based on SC22 attendee feedback we plan to adjust the format for SC23
+to include additional lightning talks, panels, and open discussion. The content
+of technical sessions will be driven by the mix of accepted submissions curated
+by the program chairs. We will offer two submission tracks: one for full paper
+submissions, and one for lightning talks. 
+
+Full paper submissions will receive at least 3 peer reviews in the SC23
+submission system on the basis of scientific validity, impact to the field,
+reproducibility, and opportunity for interactive discussion at the workshop.
+The program committee will discuss the submissions and their reviews over a
+conference call moderated by the program chairs; final proceedings will be
+selected by majority vote of the committee. As in all previous years, accepted
+submissions will be published by the IEEE Computer Society for inclusion in the
+IEEE Digital Library. Artifacts for reproducibility (digital archives of code,
+README instructions, images, etc.) will be a significant factor in paper
+acceptance into the workshop. Further details are available in the “Submission
+procedure” section below.
+
+For lightning talks, participants can submit an abstract that will be reviewed
+by the program committee. Our lightning talk track is meant to showcase demos,
+exploratory and late-breaking work, pain-points or shortcomings in current
+container/virtualization technologies, and projects that may not be fleshed-out
+enough to warrant a paper submission. We especially encourage lightning talk
+submissions from early career participants and people who are relatively new to
+the world of containers/virtualization.
 
 ### Diversity and inclusivity
-The CANOPIE-HPC organizers embrace diversity and inclusion. We are committed to equal opportunity for everyone, regardless of race, color, religion, sex, national origin, age, disability, genetic information, gender identity, sexual orientation, or status as a parent, among other things. We understand that today’s workforce is more diverse than ever and that the nation’s best and brightest represent an endless variety of cultural, geographical, and educational backgrounds; life experiences; and perspectives. We welcome this because we recognize that workforce diversity, when fully leveraged, leads to the inclusion of more ideas and viewpoints, which in turn leads to more creativity and innovation. When individuals are able to bring their whole selves to work, they thrive and HPC thrives.
+
+Similarly to the broader field of HPC, the organizers recognize concerns with
+diversity and inclusion in CANOPIE-HPC. We want to continue to improve
+diversity and inclusion at leadership, program committee, and participation
+levels.  The expanded lightning talks session is intended to lower the barrier
+to entry in the workshop and involve more early-career and non-expert
+participants. We also plan to include an open discussion section to invite
+additional audience questions and participation.  Virtual attendance (another
+opportunity for inclusion) will be guaranteed. We’ll make sure we have someone
+from the program community monitoring the chat throughout the workshop to
+address any issues or questions from our virtual attendees.  
 
 ### Submission procedure
-Accepted manuscripts will be published in IEEE Computer Society.
 
-Manuscripts should use the IEEE Transactions format; templates are available for Microsoft Word and LaTeX (though note that the IEEEtran class comes with most LaTeX installations). Manuscripts must be at least 6 pages in the IEEE Transactions format, including figures, tables, and references. There is no maximum, but writing should be concise, and manuscript length must be commensurate with contribution size.
+Accepted manuscripts will be published in IEEE Computer Society.  Manuscripts
+should use the IEEE Transactions format; templates are available for Microsoft
+Word and LaTeX (though note that the IEEEtran class comes with most LaTeX
+installations). Manuscripts must be at least 6 pages in the IEEE Transactions
+format, including figures, tables, and references. There is no maximum, but
+writing should be concise, and manuscript length must be commensurate with
+contribution size. 
 
-We enthusiastically welcome original, high-quality submissions within the scope above. These may describe complete studies; work-in-progress research; position papers on controversial, emerging, or hot topics; state of the practice; or any other manuscript the authors believe should be included in the CANOPIE-HPC program. We encourage submissions from academia, industry, government, and/or any other type of institution.
+We enthusiastically welcome original, high-quality submissions within the scope
+above. These may describe complete studies; work-in-progress research; position
+papers on controversial, emerging, or hot topics; state of the practice; or any
+other manuscript the authors believe should be included in the CANOPIE-HPC
+program. We encourage submissions from academia, industry, government, and/or
+any other type of institution.  Each manuscript will be assessed using peer
+review by program committee members (or outside reviewers, if needed) on the
+basis of scientific validity, impact to the field, reproducibility,
+inclusivity, and opportunity for useful and lively discussion at the workshop.
+Review will be single-masked; i.e., reviewers will know authors’ identities,
+but not vice versa. Authors should not anonymize their manuscripts. Each
+manuscript submission will be checked using anti-plagiarism software and can
+expect to have at least 3 reviews.
 
-Each manuscript will be assessed using peer review by program committee members (or outside reviewers, if needed) on the basis of scientific validity, impact to the field, reproducibility, inclusivity, and opportunity for useful and lively discussion at the workshop. Review will be single-masked; i.e., reviewers will know authors’ identities, but not vice versa. Authors should not anonymize their manuscripts.
+In conjunction with the SC Reproducibility Initiative, submissions should be as
+transparent as possible regarding all methods. Submissions are also expected to
+provide reproducibility artifacts such as reproduction instructions, source
+code, build recipes, and/or container images. These should be included as part
+of the submission in the form of 
+[Artifact Description/Artifact Evaluation appendices](https://sc23.supercomputing.org/program/papers/reproducibility-appendices-badges/),
+which adhere to an established format adopted by SC23.
 
-In conjunction with the SC Reproducibility Initiative, submissions should be transparent as possible regarding all methods, and when appropriate, they should provide reproducibility artifacts such as reproduction instructions, source code, build recipes, and/or container images. These should be presented in a manner convenient for readers; e.g., prose instructions might fit well as an appendix in the submitted PDF, while source code or an image repository URLs could go in a footnote.
+The program committee will discuss the submissions and their reviews and select
+the program over a video conference meeting. Submissions will be assessed
+as-is, with no expectation of substantive revision after peer review, though
+some submissions may be accepted conditional on specified changes
+(“shepherded”).
 
-The program committee will discuss the submissions and their reviews and select the program over a video conference meeting. Submissions will be assessed as-is, with no expectation of substantive revision after peer review, though some submissions may be accepted conditional on specified changes (“shepherded”).
-
-//Submit your manuscript using the [SC23 web system](https://submissions.supercomputing.org/?page=Submit&id=SC23WorkshopCANOPIEHPCSubmission&site=sc23).
+Submit your manuscript using the [SC23 web system](https://submissions.supercomputing.org/?page=Submit&id=SC23WorkshopCANOPIEHPCSubmission&site=sc23).

--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -153,4 +153,6 @@ as-is, with no expectation of substantive revision after peer review, though
 some submissions may be accepted conditional on specified changes
 (“shepherded”).
 
-Submit your manuscript using the [SC23 web system](https://submissions.supercomputing.org/?page=Submit&id=SC23WorkshopCANOPIEHPCSubmission&site=sc23).
+Submit your [SC23 CANOPIE-HPC paper](https://submissions.supercomputing.org/?args=Aprcnt3DxGzb0zU3TJUHtGyfHfbQIf0zU30Jprcnt3DbATzU30IXrfGzIXrf9_aTz0Cx0zfsGRRa_THQP0Aprcnt3DxfGzU3ACIIfb0HQP0Aprcnt3DxfTtUbprcnt3DsfGQUIYprcnt3DbTtUbb0XfQbGzt9hTzYprcnt3D40bprcnt3DQxGdbUfTzYprcnt3D40QHHGdbUfTzYprcnt3D40Iprcnt3Dxprcnt3DGdbUfTrAprcnt3DxGzU3ACI0IQ3TrJUHtGzU3ACI0IQ3TEGch_9D)
+
+Submit your [SC23 CANOPIE-HPC lightning talk](https://submissions.supercomputing.org/?args=Aprcnt3DxGzb0zU3TJUHtGyfHfbQIf0zU30Jprcnt3DbATzU30IXrfGzIXrf_hMTz0Cx0zfsGRRa_THQP0Aprcnt3DxfGzU3ACIIfb0HQP0Aprcnt3DxfTtUbprcnt3DsfGQUIYprcnt3DbTtUbb0XfQbGzt9hTzYprcnt3D40bprcnt3DQxGdbUfTzYprcnt3D40QHHGdbUfTzYprcnt3D40Iprcnt3Dxprcnt3DGdbUfTrAprcnt3DxGzU3ACI0IQ3TrJUHtGzU3ACI0IQ3TEGch_9a)

--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -152,6 +152,7 @@ as-is, with no expectation of substantive revision after peer review, though
 some submissions may be accepted conditional on specified changes
 (“shepherded”).
 
-Submit your [SC23 CANOPIE-HPC paper](https://submissions.supercomputing.org/?args=Aprcnt3DxGzb0zU3TJUHtGyfHfbQIf0zU30Jprcnt3DbATzU30IXrfGzIXrf9_aTz0Cx0zfsGRRa_THQP0Aprcnt3DxfGzU3ACIIfb0HQP0Aprcnt3DxfTtUbprcnt3DsfGQUIYprcnt3DbTtUbb0XfQbGzt9hTzYprcnt3D40bprcnt3DQxGdbUfTzYprcnt3D40QHHGdbUfTzYprcnt3D40Iprcnt3Dxprcnt3DGdbUfTrAprcnt3DxGzU3ACI0IQ3TrJUHtGzU3ACI0IQ3TEGch_9D)
+Submit your [SC23 CANOPIE-HPC paper](https://submissions.supercomputing.org/?page=Submit&id=SC23WorkshopCANOPIEHPCSubmission&site=sc23)
 
-Submit your [SC23 CANOPIE-HPC lightning talk](https://submissions.supercomputing.org/?args=Aprcnt3DxGzb0zU3TJUHtGyfHfbQIf0zU30Jprcnt3DbATzU30IXrfGzIXrf_hMTz0Cx0zfsGRRa_THQP0Aprcnt3DxfGzU3ACIIfb0HQP0Aprcnt3DxfTtUbprcnt3DsfGQUIYprcnt3DbTtUbb0XfQbGzt9hTzYprcnt3D40bprcnt3DQxGdbUfTzYprcnt3D40QHHGdbUfTzYprcnt3D40Iprcnt3Dxprcnt3DGdbUfTrAprcnt3DxGzU3ACI0IQ3TrJUHtGzU3ACI0IQ3TEGch_9a)
+Submit your [SC23 CANOPIE-HPC lightning talk](https://submissions.supercomputing.org/?page=Submit&id=SC23WorkshopCANOPIEHPCLightningTalkSubmission&site=sc23)
+

--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -117,13 +117,12 @@ address any issues or questions from our virtual attendees.
 
 ### Submission procedure
 
-Accepted manuscripts will be published in IEEE Computer Society.  Manuscripts
-should use the IEEE Transactions format; templates are available for Microsoft
-Word and LaTeX (though note that the IEEEtran class comes with most LaTeX
-installations). Manuscripts must be at least 6 pages in the IEEE Transactions
-format, including figures, tables, and references. There is no maximum, but
-writing should be concise, and manuscript length must be commensurate with
-contribution size. 
+Accepted manuscripts will be published in IEEE Computer Society.
+
+Upload your paper in PDF format. Papers must use the new [ACM proceedings
+templates](https://www.acm.org/publications/proceedings-template) and the CCS2012 guide.
+Manuscript length must
+be between 6 and 12 pages, including references and figures.
 
 We enthusiastically welcome original, high-quality submissions within the scope
 above. These may describe complete studies; work-in-progress research; position

--- a/docs/cfp.md
+++ b/docs/cfp.md
@@ -7,7 +7,7 @@ hide:
 
 ### Program chairs:
 
-* Alberto Madona Madonna, CSCS
+* Alberto Madonna, Swiss National Supercomputing Centre
 * Laurie Stephey, Lawrence Berkeley National Lab
 
 * Shane Canon, Lawrence Berkeley National Lab

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,7 @@ hide:
 HPC-Containers Slack channel: [Join Link](http://bit.ly/hpccslack)
 
 CANOPIE HPC Workshop @ SC23
-
-TBD
+Monday morning, November 13
 
 Held in conjunction with SC23: The International Conference for High Performance Computing, Networking, Storage and Analysis.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hide:
 HPC-Containers Slack channel: [Join Link](http://bit.ly/hpccslack)
 
 CANOPIE HPC Workshop @ SC23
-Monday morning, November 13
+Monday, November 13 8:30am–12pm (Mountain Time)
 
 Held in conjunction with SC23: The International Conference for High Performance Computing, Networking, Storage and Analysis.
 

--- a/docs/organizers.md
+++ b/docs/organizers.md
@@ -5,7 +5,7 @@ hide:
 
 ## STEERING COMMITTEE
 * Shane Canon – Lawrence Berkeley National Laboratory
-* Alberto Madona Madonna, CSCS
+* Andrew Younge – Sandia National Laboratories
 
 ## PROGRAM CHAIRS
 * Alberto Madona Madonna, CSCS

--- a/docs/organizers.md
+++ b/docs/organizers.md
@@ -8,7 +8,7 @@ hide:
 * Andrew Younge – Sandia National Laboratories
 
 ## PROGRAM CHAIRS
-* Alberto Madona Madonna, CSCS
+* Alberto Madonna, Swiss National Supercomputing Centre
 * Laurie Stephey, Lawrence Berkeley National Lab
 
 <!---

--- a/docs/organizers.md
+++ b/docs/organizers.md
@@ -4,12 +4,12 @@ hide:
 ---
 
 ## STEERING COMMITTEE
-* Andrew Younge – Sandia National Laboratories
 * Shane Canon – Lawrence Berkeley National Laboratory
+* Alberto Madona Madonna, CSCS
 
 ## PROGRAM CHAIRS
-* Laurie Stephey, Lawrence Berkeley National Lab
 * Alberto Madona Madonna, CSCS
+* Laurie Stephey, Lawrence Berkeley National Lab
 
 <!---
 * Carlos Eduardo Arango Gutierrez, Red Hat, Inc.

--- a/docs/topics.md
+++ b/docs/topics.md
@@ -2,21 +2,24 @@
 hide:
   - navigation
 ---
-
-* Experience using containers for HPC applications including data analytics, machine learning, modeling and simulation.
-* Utilizing Containers to improve Portability and Reproducibility
-* Container services orchestration and micro-services with HPC
-* Scheduling of containerized workflows and services
-* HPC Container Runtimes
-* Virtualization in supercomputing environments & HPC clusters
-* Container runtime designs for Exascale
-* HPC in the cloud
-* Accelerator and GPU virtualization
-* Container Image Construction
-* Container security and trust models including container distribution
-* In-situ HPC & analysis coupling experiments
-* Workflow ensemble coupling with containers
+* Container runtimes, virtual machine implementations, and other related technologies
+* Perspectives from container framework developers and  maintainers
+* System and architecture portability
+* Scientific reproducibility, including FAIR considerations 
+* Experience reports from users, developers, and system administrators
+* Lessons from exascale
+* HPC in the cloud and/or cloud in the HPC
+* GPUs, accelerators, proprietary interconnects, and other hardware considerations
+* Security considerations when adopting container technologies, including zero trust models
+* Container and virtual machine image management, including distribution and archiving
+* Workflows, including interaction between traditional HPC applications and containerized workflows or edge services
 * Performance and scaling studies with containers and/or VMs
-* On-node resource partitioning with OS mechanisms
-* Combined container and OS/VM designs
-* DevOps models with containers and image registries
+* Orchestration, scheduling, and/or resource management of jobs and microservices
+* New interaction techniques such as web apps (Jupyter, Rstudio, etc.)
+* Community standards, including OCI 
+* Role of containerization in DevOps (ex: Gitlab CI/CD) 
+* Efforts to provide and curate containers
+* Improving container user experience
+* Future of containers (ex: web assembly, portability) 
+* Perspectives on container outreach- convincing native application users/devs to make the jump
+


### PR DESCRIPTION
* Update CFP with SC23 text from google doc
* Updated topics list to match CFP
* Add some line wrapping to make text easier to edit/read
* Alphabetize organizers by last name
* Add submission deadlines
* Add workshop date to main page