### PR TITLE
add links to conference proceedings from past years

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,4 +19,16 @@ Held in conjunction with SC23: The International Conference for High Performance
 
 ### ABOUT
 
-Containers and New Orchestration Paradigms for Isolated Environments in HPC (CANOPIE-HPC) is a workshop focusing on containerization, virtualization, and other methods to implement user-defined, bring-your-own, or isolated software environments. The fifth workshop will be hosted at the 2023 International Conference for High Performance Computing, Networking, Storage and Analysis (SC23). The objective of this workshop is to serve as the principal venue for leaders in the field to stimulate research and interactions in relation to cutting-edge container technologies, virtualization, and OS system software as it relates to supporting High Performance Computing (HPC).
+Containers and New Orchestration Paradigms for Isolated Environments in HPC
+(CANOPIE-HPC) is a workshop focusing on containerization, virtualization, and
+other methods to implement user-defined, bring-your-own, or isolated software
+environments. The fifth workshop will be hosted at the 2023 International
+Conference for High Performance Computing, Networking, Storage and Analysis
+(SC23). The objective of this workshop is to serve as the principal venue for
+leaders in the field to stimulate research and interactions in relation to
+cutting-edge container technologies, virtualization, and OS system software as
+it relates to supporting High Performance Computing (HPC).
+
+### Proceedings
+
+[Proceedings from previous CANOPIE-HPC workshps](https://ieeexplore.ieee.org/xpl/conhome/1835005/all-proceedings)

--- a/docs/prev/2019/program.md
+++ b/docs/prev/2019/program.md
@@ -23,3 +23,5 @@ Papers: [Papers](https://conferences.computer.org/sc19w/2019/#!/toc/0)
 | |  Popper 2.0: A Multi-container Workflow Execution Engine For Testing Complex Applications and Validating Scientific Explorations [PDF](https://www.canopie-hpc.org/wp-content/uploads/2019/12/20191118-popper2.0-canopie-workshop.pdf) – Quincy Wofford|
 | | Running InfiniBand and GPU Accelerated MPI Applications in a Kubernetes Environment [PDF](https://www.canopie-hpc.org/wp-content/uploads/2019/12/MPI-and-k8s-with-ParallelJob-2019-11-sc-workshop.pdf) – Josh Hursey|
 | 17:30 – 17:31 | Closing Remarks|
+
+## [Proceedings](https://ieeexplore.ieee.org/xpl/conhome/8949328/proceeding) from CANOPIE-HPC SC19

--- a/docs/prev/2020/program.md
+++ b/docs/prev/2020/program.md
@@ -35,3 +35,4 @@ November 12, 2020
 |         | What are the impediments to making container-based workflows the default deployment model for HPC? |
 | 6:00 pm | Wrap-up |
 
+## [Proceedings](https://ieeexplore.ieee.org/xpl/conhome/9297035/proceeding) from CANOPIE-HPC SC20

--- a/docs/prev/2021/program.md
+++ b/docs/prev/2021/program.md
@@ -36,3 +36,5 @@ Sunday, November 14th, 2021
 |         | Cory Snavely – LBNL/NERSC|
 |         | Dan Walsh – Red Hat|
 | 5: 30 pm | Closing Remarks|
+
+## [Proceedings](https://ieeexplore.ieee.org/xpl/conhome/9652565/proceeding) from CANOPIE-HPC SC21

--- a/docs/prev/2022/program.md
+++ b/docs/prev/2022/program.md
@@ -7,14 +7,7 @@ hide:
 Monday, November 14th, 2022
 8:30am – 5:00pm CST
 
-## Papers
-
-The papers were published by IEEE and can be found at:
-
-https://www.computer.org/csdl/proceedings/canopie-hpc/2022/1L6LKeG7tZu
-
 ** Note all times list CENTRAL TIME (UTC–6) **
-
 
 ## Agenda
 

--- a/docs/prev/2022/program.md
+++ b/docs/prev/2022/program.md
@@ -167,3 +167,5 @@ We plan to have a combination of Invited Speakers, Research Paper Presentations,
     </tr>
 </tbody>
 </table>
+
+## [Proceedings](https://ieeexplore.ieee.org/xpl/conhome/10029390/proceeding) from CANOPIE-HPC SC22


### PR DESCRIPTION
Adding links to the formal conference proceedings on the landing page (all years) and for the specific year